### PR TITLE
Prevent conversion to CRLF on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.js text eol=lf


### PR DESCRIPTION
Update to prevent conversion to CRLF of .js files on Windows and avoid further issues with the eslint linebreak-style.